### PR TITLE
local debugging with vscode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,10 @@ jobs:
           export CXX=/usr/bin/g++-13
           cmake -S $GITHUB_WORKSPACE -B ./build -G "Ninja" \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+            -DCMAKE_CXX_COMPILER=/usr/bin/g++-13 \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
             -DJUCE_PATH=$GITHUB_WORKSPACE/juce/JUCE-7.0.9 \
-            -DCMAKE_CXX_COMPILER=/usr/bin/g++-13
+            -DRUN_CLANG_TIDY=true
         shell: bash
 
       - name: Build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "(gdb) Launch",
+      "type": "cppdbg",
+      "request": "launch",
+      // Resolved by CMake Tools:
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [
+        {
+          // add the directory where our target was built to the PATHs
+          // it gets resolved by CMake Tools:
+          "name": "PATH",
+          "value": "${env:PATH}:${command:cmake.getLaunchTargetDirectory}"
+        },
+      ],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "cmake.generator": "Ninja",
+  "cmake.exportCompileCommandsFile": true,
+  "cmake.configureSettings": {
+    "CMAKE_BUILD_TYPE": "Debug",
+    "JUCE_PATH": "${env:HOME}/dev/JUCE/",
+    "RUN_CLANG_TIDY": false
+  }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ file(GLOB_RECURSE SRC_FILES
 
 target_sources(anyMidi PRIVATE ${SRC_FILES})
 
-if (UNIX)
+if (UNIX AND RUN_CLANG_TIDY)
 	# Run clang-tidy only on linux
 	foreach(version RANGE 15 17)
 		list(APPEND CLANG_TIDY_VERSIONS "clang-tidy-${version}")	


### PR DESCRIPTION
disable clang-tidy for local debugging, enable for CI